### PR TITLE
move pry to dev/test dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,12 +11,12 @@ gem "bcrypt", "~> 3.1.7"
 
 # https://github.com/doorkeeper-gem/doorkeeper/issues/742
 gem "doorkeeper", "4.0.0.rc2"
-gem "pry"
 gem "jsonapi-serializers"
 
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug"
+  gem "pry"
 end
 
 group :test do


### PR DESCRIPTION
probably don't want users prying too much in production
